### PR TITLE
conf: meta server list use fqdn

### DIFF
--- a/src/rdsn/src/common/replication_common.cpp
+++ b/src/rdsn/src/common/replication_common.cpp
@@ -480,19 +480,19 @@ bool replica_helper::load_meta_servers(/*out*/ std::vector<dsn::rpc_address> &se
         std::vector<std::string> hostname_port;
         uint32_t ip = 0;
         utils::split_args(s.c_str(), hostname_port, ':');
-        dassert(2 == hostname_port.size(),
-                "invalid address '{}' specified in config [{}].{}",
-                s.c_str(),
-                section,
-                key);
-        unsigned int port_num;
-        dassert(dsn::internal::buf2unsigned(hostname_port[1], port_num) && port_num < UINT16_MAX,
-                "invalid address '{}' specified in config [{}].{}",
-                s.c_str(),
-                section,
-                key);
+        dassert_f(2 == hostname_port.size(),
+                  "invalid address '{}' specified in config [{}].{}",
+                  s.c_str(),
+                  section,
+                  key);
+        uint32_t port_num = 0;
+        dassert_f(dsn::internal::buf2unsigned(hostname_port[1], port_num) && port_num < UINT16_MAX,
+                  "invalid address '{}' specified in config [{}].{}",
+                  s.c_str(),
+                  section,
+                  key);
         if (0 != (ip = ::dsn::rpc_address::ipv4_from_host(hostname_port[0].c_str()))) {
-            addr.assign_ipv4(ip, (uint16_t)port_num);
+            addr.assign_ipv4(ip, static_cast<uint16_t>(port_num));
         } else if (!addr.from_string_ipv4(s.c_str())) {
             derror_f("invalid address '{}' specified in config [{}].{}", s, section, key);
             return false;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
support fqdn

### What is changed and how does it work?
meta server conf: server_list can use host:ip
